### PR TITLE
branch name is used for subdomain so must meet DNS-1123

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -29,7 +29,7 @@ podTemplate(
                 zone=zone.trim()
                 branch=env.BRANCH_NAME
                 // Sanitize the branch name so it can be made part of the pvc 
-                branch=branch.replaceAll("/","-");
+                branch=branch.replaceAll("/","-").take(63).toLowerCase();
                 pvc = "${branch}-${zone}"
 
                 echo "I am checking for a maven cache for ${branch} in ${zone}" 


### PR DESCRIPTION
I used some uppercase letters in my branch name and found out what a terrible person Glenn was.

```
[Pipeline] echo
I am checking for a maven cache for feature-SDO-151-integrate-contrast-ce in us-east-1c
[Pipeline] readYaml
[Pipeline] sh
+ rm -rf dynamicclaim.yaml
[Pipeline] writeYaml
[Pipeline] sh
+ kubectl apply -f dynamicclaim.yaml
The PersistentVolumeClaim "feature-SDO-151-integrate-contrast-ce-us-east-1c" is invalid: metadata.name: Invalid value: "feature-SDO-151-integrate-contrast-ce-us-east-1c": a DNS-1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*')
```