### PR TITLE
Added a with-contrast profile for Contrast Security CE

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -222,6 +222,7 @@
               <properties>
                 <cargo.daemon.url>http://localhost:18000</cargo.daemon.url>
                 <cargo.daemon.handleid>${project.artifactId}</cargo.daemon.handleid>
+                <cargo.jvmargs>${contrast.cargo.jvmargs}</cargo.jvmargs>
               </properties>
             </daemon>
           </configuration>
@@ -435,6 +436,49 @@
         <resin.version>4.0.64</resin.version>
         <cargo.maven.containerId>resin${resin.major-version}x</cargo.maven.containerId>
         <cargo.maven.containerUrl>https://www.caucho.com/download/resin-${resin.version}.zip</cargo.maven.containerUrl>
+      </properties>
+    </profile>
+    <profile>
+      <id>with-contrast</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>com.contrastsecurity</groupId>
+            <artifactId>contrast-maven-plugin</artifactId>
+            <version>2.6</version>
+            <executions>
+              <execution>
+                <id>install-contrast-jar</id>
+                <goals>
+                  <goal>install</goal>
+                </goals>
+              </execution>
+              <execution>
+                <id>verify-with-contrast</id>
+                <phase>post-integration-test</phase>
+                <goals>
+                  <goal>verify</goal>
+                </goals>
+              </execution>
+            </executions>
+            <configuration>
+              <username>${contrast.username}</username>
+              <apiKey>${contrast.apiKey}</apiKey>
+              <serviceKey>${contrast.serviceKey}</serviceKey>
+              <apiUrl>${contrast.apiUrl}</apiUrl>
+              <orgUuid>${contrast.orgUuid}</orgUuid>
+              <appName>${contrast.appName}</appName>
+              <serverName>${contrast.serverName}</serverName>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+      <properties>
+        <contrast.cargo.jvmargs>-javaagent:${project.build.directory}/contrast.jar</contrast.cargo.jvmargs>
+
+        <contrast.apiUrl>https://ce.contrastsecurity.com/Contrast</contrast.apiUrl>
+        <contrast.appName>JPetStore</contrast.appName>
+        <contrast.serverName>ip-10-0-1-126.ec2.internal</contrast.serverName>
       </properties>
     </profile>
   </profiles>


### PR DESCRIPTION
Include a Contrast Security CE analysis for the build when building with the `with-contrast` profile on. 

Turning one profile on means the automatic default profile (in this case `tomcat90`) is turned off, so that needs to be explicitly activated as well. The Contrast creds are stored in Jenkins as two pairs: one for the organization and one for the user.