### PR TITLE
Add OWASP Dependency Check

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -117,6 +117,7 @@ podTemplate(
                         }
                         stage('Deploy') {
                             sh('mvn -s ${MAVEN_CONFIG} -P tomcat90,with-contrast -Dcontrast.username=${CONTRAST_USERNAME} -Dcontrast.serviceKey=${CONTRAST_SERVICEKEY} -Dcontrast.apiKey=${CONTRAST_APIKEY} -Dcontrast.orgUuid=${CONTRAST_ORGUUID} deploy -DskipITs')
+                            archiveArtifacts artifacts: '**/target/dependency-check-report.*', onlyIfSuccessful: false
                             archiveArtifacts artifacts: '**/target/*.war', onlyIfSuccessful: true
                         }
                     }

--- a/pom.xml
+++ b/pom.xml
@@ -227,6 +227,22 @@
             </daemon>
           </configuration>
         </plugin>
+        <plugin>
+          <groupId>org.owasp</groupId>
+          <artifactId>dependency-check-maven</artifactId>
+          <version>${dependency.check.maven.version}</version>
+          <configuration>
+            <!-- <failBuildOnCVSS>${dependency.check.maven.failBuildOnCVSS}</failBuildOnCVSS> -->
+            <formats>HTML,XML</formats>
+          </configuration>
+          <executions>
+            <execution>
+              <goals>
+                <goal>check</goal>
+              </goals>
+            </execution>
+          </executions>
+        </plugin>
       </plugins>
     </pluginManagement>
     <plugins>
@@ -281,6 +297,10 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <groupId>org.owasp</groupId>
+        <artifactId>dependency-check-maven</artifactId>
+      </plugin>
     </plugins>
   </build>
 
@@ -322,6 +342,8 @@
     <mockito.version>3.5.13</mockito.version>
     <hsqldb.version>2.5.1</hsqldb.version>
     <module.name>org.mybatis.jpetstore</module.name>
+
+    <dependency.check.maven.version>6.0.2</dependency.check.maven.version>
   </properties>
 
   <profiles>

--- a/pom.xml
+++ b/pom.xml
@@ -234,6 +234,8 @@
           <configuration>
             <!-- <failBuildOnCVSS>${dependency.check.maven.failBuildOnCVSS}</failBuildOnCVSS> -->
             <formats>HTML,XML</formats>
+            <cveUrlModified>${dependency.check.cveUrlModified}</cveUrlModified>
+            <cveUrlBase>${dependency.check.cveUrlBase}</cveUrlBase>
           </configuration>
           <executions>
             <execution>
@@ -344,6 +346,8 @@
     <module.name>org.mybatis.jpetstore</module.name>
 
     <dependency.check.maven.version>6.0.2</dependency.check.maven.version>
+    <dependency.check.cveUrlModified>https://nexus.dhsice.name/repository/nvd.nist.gov/feeds/json/cve/1.1/nvdcve-1.1-modified.json.gz</dependency.check.cveUrlModified>
+    <dependency.check.cveUrlBase>https://nexus.dhsice.name/repository/nvd.nist.gov/feeds/json/cve/1.1/nvdcve-1.1-%d.json.gz</dependency.check.cveUrlBase>
   </properties>
 
   <profiles>


### PR DESCRIPTION
Adds OWASP Dependency Check to the build.

NIST NVD data is proxied through Nexus and can/should be used for OWASP Dependency Track as well.