### PR TITLE
Update Contrast Security plugin and our server name

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -471,7 +471,7 @@
           <plugin>
             <groupId>com.contrastsecurity</groupId>
             <artifactId>contrast-maven-plugin</artifactId>
-            <version>2.6</version>
+            <version>2.10</version>
             <executions>
               <execution>
                 <id>install-contrast-jar</id>
@@ -504,7 +504,7 @@
 
         <contrast.apiUrl>https://ce.contrastsecurity.com/Contrast</contrast.apiUrl>
         <contrast.appName>JPetStore</contrast.appName>
-        <contrast.serverName>ip-10-0-1-126.ec2.internal</contrast.serverName>
+        <contrast.serverName>ip-10-0-1-192.ec2.internal</contrast.serverName>
       </properties>
     </profile>
   </profiles>


### PR DESCRIPTION
We are only allowed one server in the free version, and it is set based on the IP address that grabs the license first. Since the last time we ran it, and a new IP address grabbed the one license.