### PR TITLE
Moved SteampunkLabs specific settings out, proxy support

### DIFF
--- a/.mvn/jvm.config
+++ b/.mvn/jvm.config
@@ -1,0 +1,1 @@
+-Djava.net.useSystemProxies=true

--- a/pom.xml
+++ b/pom.xml
@@ -247,6 +247,7 @@
         </plugin>
       </plugins>
     </pluginManagement>
+
     <plugins>
       <plugin>
         <groupId>org.codehaus.cargo</groupId>
@@ -346,8 +347,6 @@
     <module.name>org.mybatis.jpetstore</module.name>
 
     <dependency.check.maven.version>6.0.2</dependency.check.maven.version>
-    <dependency.check.cveUrlModified>https://nexus.dhsice.name/repository/nvd.nist.gov/feeds/json/cve/1.1/nvdcve-1.1-modified.json.gz</dependency.check.cveUrlModified>
-    <dependency.check.cveUrlBase>https://nexus.dhsice.name/repository/nvd.nist.gov/feeds/json/cve/1.1/nvdcve-1.1-%d.json.gz</dependency.check.cveUrlBase>
   </properties>
 
   <profiles>


### PR DESCRIPTION
The `.mvn/jvm.config` file adds command-line options automatically for anyone running Maven. The `-Djava.net.useSystemProxies=true` makes the JDK use the Windows proxy settings rather than figuring them out and reimplementing them ourselves.

I moved the settings for `dependency.check.cveUrlModified` and `dependency.check.cveUrlBase` to my `$HOME/.m2/settings.xml` file. Otherwise, it will pull from the default location rather than proxy (and cache) through Nexus.

```xml
<settings>

    <profiles>
        <profile>
            <id>steampunk</id>
            <properties>
                <dependency.check.cveUrlModified>https://nexus.dhsice.name/repository/nvd.nist.gov/feeds/json/cve/1.1/nvdcve-1.1-modified.json.gz</dependency.check.cveUrlModified>
                <dependency.check.cveUrlBase>https://nexus.dhsice.name/repository/nvd.nist.gov/feeds/json/cve/1.1/nvdcve-1.1-%d.json.gz</dependency.check.cveUrlBase>
            </properties>
        </profile>
    </profiles>

    <activeProfiles>
        <activeProfile>steampunk</activeProfile>
    </activeProfiles>

</settings>
``` 